### PR TITLE
解决git中you need to resolve your current index first的错误

### DIFF
--- a/cobra/pickup.py
+++ b/cobra/pickup.py
@@ -453,7 +453,7 @@ class Git(object):
         current_dir = os.getcwd()
         os.chdir(self.repo_directory)
 
-        cmd = "git fetch origin && git checkout " + branch
+        cmd = "git fetch origin && git reset --hard origin/{branch} && git checkout {branch}".format(branch=branch)
         p = subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
         (checkout_out, checkout_err) = p.communicate()
 


### PR DESCRIPTION
扫描日志中有时会出现需要merge的情况，而在一般情况下，拉取代码在不同分支切换是不会存在需要merge的问题的，进一步查看日志发现在出现merge报错的地方都会有
```
error: you need to resolve your current index first
```
错误出现。
该问题一般是由于从一个分支A切换到另一个分支B后，对切换后的B分支进行pull操作，因为pull操作实际上包含了fetch+merge操作，在执行 merge操作时，由于很长时间没有对B分支执行过pull/merge操作，本地的B分支库与remote中的B分支库中的差异很大（且这些差异是其他 同事开发的文件），merge时产生冲突，使得B分支的状态为merging，其实是指merge失败，还停留在merge状态，也不能执行pull操 作。这时没有解决冲突，而是从B分支上切换到其他分支时出现的。

所以在fetch的代码的地方加上了一次hard reset，以强制与远程代码同步。
```
git fetch origin && git reset --hard origin/<branch> && git checkout <branch>
```

参考链接
- https://stackoverflow.com/questions/6006737/git-merge-errors
- https://stackoverflow.com/questions/14439443/how-do-i-blow-away-my-attempt-to-resolve-git-conflicts
- https://blog.csdn.net/shjsir/article/details/52638612