### PR TITLE
判断gitlab的关键字，不能适合所有的情况，config加入domain进行判断

### DIFF
--- a/cobra/utils.py
+++ b/cobra/utils.py
@@ -134,7 +134,10 @@ class ParseArgs(object):
                 target, branch = self.target, 'master'
             else:
                 logger.critical('Target url exception: {u}'.format(u=self.target))
-            if 'gitlab' in target:
+            # 只判断gitlab的关键字，不能适合所有的情况
+            # 建议把这里设置为变量，从配置文件里面读取
+            domain = Config('git', 'domain').value
+            if domain in target:
                 username = Config('git', 'username').value
                 password = Config('git', 'password').value
             else:

--- a/config.template
+++ b/config.template
@@ -52,6 +52,7 @@ password:
 [git]
 username:
 password:
+domain:
 private_token:
 # http://xxx.gitlab.com/api/v3/projects/all
 gitlab_url:


### PR DESCRIPTION
cobra2-alpha0.5的版本，使用私有的gitlab地址单个库的扫描，在后台日志上要去输入用户密码，发现代码的判断不准确导致，在此处进行改进。