### PR TITLE
兼容Python3的输出

### DIFF
--- a/cobra/log.py
+++ b/cobra/log.py
@@ -120,6 +120,8 @@ class ColorizingStreamHandler(logging.StreamHandler):
             if not self.is_tty:
                 if message and message[0] == "\r":
                     message = message[1:]
+                if sys.version > '3':
+                    message = message.decode()
                 stream.write(message)
             else:
                 self.output_colorized(message)


### PR DESCRIPTION
在python3.7下会出现以下问题

[Python3下异常](https://github.com/WhaleShark-Team/cobra/issues/1291)

故设置，当python3时候，将message由bytes类型解码为str类型
