### PR TITLE
移除 pip 版本

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ rarfile==2.7
 prettytable==0.7.2
 requests==2.20.0
 pytest==3.0.6
-pip==9.0.1
 phply==1.0.0
 Werkzeug==0.15.3
 ConcurrentLogHandler==0.9.1


### PR DESCRIPTION
安装时候即是通过 `pip install -r requirements.txt`，系统已经含有 `pip`；将其包含在依赖里反而会降低系统 `pip` 的版本